### PR TITLE
Update STL Visitor interface to inherit from MTL and not LTL

### DIFF
--- a/include/forek/formula/visitor/stl/visitor.hpp
+++ b/include/forek/formula/visitor/stl/visitor.hpp
@@ -2,7 +2,7 @@
 #define FOREK_FORMULA_VISITOR_STL_VISITOR_HPP
 
 #include <forek/formula/visitor/arithmetic/visitor.hpp>
-#include <forek/formula/visitor/ltl/visitor.hpp>
+#include <forek/formula/visitor/mtl/visitor.hpp>
 
 namespace forek::formula {
 namespace core::operation::stl {
@@ -12,7 +12,7 @@ class Predicate;
 
 namespace visitor::stl {
 template <typename T>
-class Visitor : public forek::formula::visitor::ltl::Visitor<T> {
+class Visitor : public forek::formula::visitor::mtl::Visitor<T> {
    protected:
     visitor::arithmetic::Visitor<T>& solver_;
 


### PR DESCRIPTION
STL should inherit from MTL because in addition to supporting predicates, it should also support bounded operators.

The STL grammar imports the MTL grammar implying that this was the intention.